### PR TITLE
Removing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @hedss @shaunmulligan @xginn8 @garethtdavies
+*       @shaunmulligan @xginn8 @garethtdavies


### PR DESCRIPTION
Removing Hedss from codeowners to save being pinged.

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>