### PR TITLE
README: CLI supports service env vars now

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Your name is Gareth Updated
 
 #### 3.3 Service Variables
 
-Environment variables are accessible to all services running on a device, whereas service variables are assigned to a specific service. Service variables can be created via the dashboard or via the API, either for the application or per device. The CLI does not currently support service-specific variables.
+Environment variables are accessible to all services running on a device, whereas service variables are assigned to a specific service. Service variables can be created via the dashboard, the CLI, or via the API, either for the application or per device.
 
 Create a new device service variable named `MY_NAME` from the _Device Service Variables_ tab of the Device dashboard and give it a unique value. As we only have a single service for this application, the default service value of `main` is the only available option.
 


### PR DESCRIPTION
https://github.com/balena-io/balena-cli/pull/1529

This PR merged support for setting env vars on microservices
via the CLI so we can remove this text about it not being supported.

We could also improve the doc by adding an example of setting a
service env var via the CLI but this PR is just to remove the
unsupported reference.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>